### PR TITLE
Tests for measures (issue #9)

### DIFF
--- a/Documentation/Ensamble.md
+++ b/Documentation/Ensamble.md
@@ -2,6 +2,12 @@
 
 This document describes the Ensamble DSL, which defines how services and agents are composed and hosted within a Tinkwell system. Each file (typically with a `.tw` extension) describes a tree of runners, services, and their properties, used by the **Supervisor** to orchestrate process startup and configuration.
 
+You can create a starting poin to customize using:
+
+```bash
+tw templates use ensamble_configuration
+```
+
 ## Syntax Overview
 
 The most common way to define the system composition is by using the `compose` directive. You can also include other files with `import`.
@@ -179,7 +185,7 @@ runner "{{ name }}" "{{ host.grpc }}" {
 ## Complete Example
 
 ```text
-// File: /etc/tinkwell/ensemble.tw
+// File: /etc/tinkwell/ensamble.tw
 
 // Import shared definitions, which might contain the 'store' service
 import "shared_services.tw"

--- a/Documentation/Getting-Started.md
+++ b/Documentation/Getting-Started.md
@@ -62,14 +62,20 @@ mv ./tinkwell-cert.pem ./tinkwell-cert.crt
 sudo trust anchor --store ./tinkwell-cert.crt
 ```
 
-## 2. Understand the Ensemble Configuration
+## 2. Understand the Ensamble Configuration
 
 The `ensamble.tw` file is the heart of your application's configuration, defining all the processes (runners) that the Supervisor will manage.
 
--   Review the [Ensemble Syntax documentation](./Ensamble.md) to understand how runners and firmlets are defined.
+-   Review the [Ensamble Syntax documentation](./Ensamble.md) to understand how runners and firmlets are defined.
 -   Open the default `ensamble.tw` file (in the `Assets` project if in VS or the output folder if in "production") to see a practical example.
 
-You can create a starting point with all the basic features already configured using `tw templates create`. After you modified the configuration you should run the linters to catch common mistakes:
+You can create a starting point with all the basic features already configured using:
+
+```bash
+tw templates use ensamble_configuration
+```
+
+After you modified the configuration you should run the linters to catch common mistakes:
 
 ```bash
 ./tw ensamble lint ./ensamble.tw
@@ -99,4 +105,4 @@ You now have a running Tinkwell system. To learn more, explore the following res
 - [Glossary](./Glossary.md): Understand the core concepts and terminology.
 - [CLI Reference](./CLI.md): Discover all the available commands for monitoring and debugging.
 - [Derived Measures](./Derived-measures.md): Learn how to create custom measures.
-- [How-To](./How-to.md): Quick guide for doing the most common tasks.
+- [How-To](./How-To.md): Quick guide for doing the most common tasks.

--- a/Documentation/Glossary.md
+++ b/Documentation/Glossary.md
@@ -1,6 +1,6 @@
 # Glossary
 
-[A](#agent) | [C](#configuration) | [D](#derived-measure) | [E](#ensemble) | [F](#firmlet) | [G](#grpc-host) | [H](#health-check-service) | [M](#machine) | [O](#orchestrator-service) | [R](#reactor) | [S](#service) | [W](#watchdog)
+[A](#agent) | [C](#configuration) | [D](#derived-measure) | [E](#ensamble) | [F](#firmlet) | [G](#grpc-host) | [H](#health-check-service) | [M](#machine) | [O](#orchestrator-service) | [R](#reactor) | [S](#service) | [W](#watchdog)
 
 ---
 
@@ -11,9 +11,9 @@ A synonym for [firmlet](#firmlet), when it does not expose a gRPC service (but c
 *See also:* [Firmlet](#firmlet), [gRPC host](#grpc-host), [DLL host](#dll-host)
 
 #### Configuration
-The set of files that define the system's behavior, including the [Ensemble](#ensemble) file and the configurations for [derived measures](#derived-measure).
+The set of files that define the system's behavior, including the [Ensamble](#ensamble) file and the configurations for [derived measures](#derived-measure).
 
-*See also:* [Ensemble](#ensemble), [Derived Measure](#derived-measure)
+*See also:* [Ensamble](#ensamble), [Derived Measure](#derived-measure)
 
 #### Derived Measure
 A [measure](#measure) whose value is calculated from other measures. The [Reducer](#reducer) is responsible for computing its value. Every measure is associated with its [unit of measure](./Units.md). Derived measures are defined in their own configuration file (see [Derived Measures Configuration](./Derived-measures.md)).
@@ -30,7 +30,7 @@ A [host](#host) that loads [agents](#agent) packaged as libraries. It does not e
 
 *See also:* [Host](#host), [Agent](#agent), [Firmlet](#firmlet)
 
-#### Ensemble
+#### Ensamble
 The description of a set of [runners](#runner) and their options.
 
 *See also:* [Runner](#runner), [Firmlet](#firmlet), [Supervisor](#supervisor)
@@ -119,9 +119,9 @@ A [service](#service) implementing `Tinkwell.Store` that keeps track of all the 
 *See also:* [Measure](#measure), [Derived Measure](#derived-measure), [Reducer](#reducer), [Reactor](#reactor)
 
 #### Supervisor
-The entry-point of a Tinkwell application. It's in charge of parsing the [ensemble](#ensemble) configuration file, starting the required processes, and monitoring their health at the process level. There can be only one per machine and only one master per [system](#system).
+The entry-point of a Tinkwell application. It's in charge of parsing the [ensamble](#ensamble) configuration file, starting the required processes, and monitoring their health at the process level. There can be only one per machine and only one master per [system](#system).
 
-*See also:* [Runner](#runner), [Ensemble](#ensemble), [Orchestrator (Service)](#orchestrator-service)
+*See also:* [Runner](#runner), [Ensamble](#ensamble), [Orchestrator (Service)](#orchestrator-service)
 
 #### System
 One or more machines running a Tinkwell installation.

--- a/Tests/Tinkwell.Measures.Tests/RegistryTests.cs
+++ b/Tests/Tinkwell.Measures.Tests/RegistryTests.cs
@@ -1,0 +1,274 @@
+using Tinkwell.Measures.Storage;
+using UnitsNet;
+
+namespace Tinkwell.Measures.Tests;
+
+public class RegistryTests
+{
+    [Fact]
+    public async Task RegisterMeasure_SuccessfullyRegistersMeasure()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+        var definition = new MeasureDefinition { Name = "TestMeasure", Type = MeasureType.Number };
+        var metadata = new MeasureMetadata(DateTime.UtcNow);
+
+        // Act
+        await registry.RegisterAsync(definition, metadata, CancellationToken.None);
+
+        // Assert
+        var registeredMeasure = registry.Find("TestMeasure");
+        Assert.NotNull(registeredMeasure);
+        Assert.Equal("TestMeasure", registeredMeasure.Name);
+    }
+
+    [Fact]
+    public async Task RegisterMeasure_ThrowsExceptionForDuplicateMeasure()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+        var definition = new MeasureDefinition { Name = "DuplicateMeasure", Type = MeasureType.Number };
+        var metadata = new MeasureMetadata(DateTime.UtcNow);
+
+        await registry.RegisterAsync(definition, metadata, CancellationToken.None);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            async () => await registry.RegisterAsync(definition, metadata, CancellationToken.None));
+        Assert.Contains("is already registered", exception.Message);
+    }
+
+    [Theory]
+    [InlineData(null, typeof(ArgumentNullException), "Value cannot be null. (Parameter 'Name')")]
+    [InlineData("", typeof(ArgumentException), "The value cannot be an empty string or composed entirely of whitespace. (Parameter 'Name')")]
+    [InlineData(" ", typeof(ArgumentException), "The value cannot be an empty string or composed entirely of whitespace. (Parameter 'Name')")]
+    public async Task RegisterMeasure_ThrowsExceptionForInvalidMeasureName(string? invalidName, Type expectedExceptionType, string expectedMessage)
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+        
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync(expectedExceptionType,
+            async () => new MeasureDefinition { Name = invalidName!, Type = MeasureType.Number });
+        Assert.Equal(expectedMessage, exception.Message);
+    }
+
+    [Fact]
+    public async Task RegisterMeasure_ThrowsExceptionForStringMeasureWithUnit()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+        var definition = new MeasureDefinition { Name = "StringMeasureWithUnit", Type = MeasureType.String, QuantityType = "Length", Unit = "Meter" };
+        var metadata = new MeasureMetadata(DateTime.UtcNow);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            async () => await registry.RegisterAsync(definition, metadata, CancellationToken.None));
+        Assert.Contains("cannot have a unit of measure because it's a string", exception.Message);
+    }
+
+    [Fact]
+    public async Task RegisterMeasure_ThrowsExceptionForInvalidUnitCombination()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+        var definition = new MeasureDefinition { Name = "InvalidUnitMeasure", Type = MeasureType.Number, QuantityType = "InvalidQuantity", Unit = "InvalidUnit" };
+        var metadata = new MeasureMetadata(DateTime.UtcNow);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            async () => await registry.RegisterAsync(definition, metadata, CancellationToken.None));
+        Assert.Contains("are not a valid combination", exception.Message);
+    }
+
+    [Fact]
+    public async Task RegisterUpdateFind_FlowsCorrectly()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+        var definition = new MeasureDefinition { Name = "Temperature", Type = MeasureType.Number };
+        var metadata = new MeasureMetadata(DateTime.UtcNow);
+
+        // Act - Register
+        await registry.RegisterAsync(definition, metadata, CancellationToken.None);
+
+        // Act - Update
+        var initialValue = new MeasureValue(Length.FromMeters(25.5));
+        await registry.UpdateAsync("Temperature", initialValue, CancellationToken.None);
+
+        // Act - Find
+        var measure = registry.Find("Temperature");
+
+        // Assert
+        Assert.NotNull(measure);
+        Assert.Equal(initialValue, measure.Value);
+
+        // Act - Update again
+        var updatedValue = new MeasureValue(Length.FromMeters(26.0));
+        await registry.UpdateAsync("Temperature", updatedValue, CancellationToken.None);
+
+        // Act - Find again
+        measure = registry.Find("Temperature");
+
+        // Assert
+        Assert.NotNull(measure);
+        Assert.Equal(updatedValue, measure.Value);
+    }
+
+    [Fact]
+    public async Task Update_ThrowsExceptionForConstantMeasure()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+        var definition = new MeasureDefinition { Name = "ConstantMeasure", Type = MeasureType.Number, Attributes = MeasureAttributes.Constant };
+        var metadata = new MeasureMetadata(DateTime.UtcNow);
+        await registry.RegisterAsync(definition, metadata, CancellationToken.None);
+        await registry.UpdateAsync("ConstantMeasure", new MeasureValue(Length.FromMeters(10.0)), CancellationToken.None);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            async () => await registry.UpdateAsync("ConstantMeasure", new MeasureValue(Length.FromMeters(20.0)), CancellationToken.None));
+        Assert.Contains("Cannot update a constant measure", exception.Message);
+    }
+
+    [Fact]
+    public async Task Update_ThrowsExceptionForIncompatibleValueType()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+        var definition = new MeasureDefinition { Name = "NumericMeasure", Type = MeasureType.Number };
+        var metadata = new MeasureMetadata(DateTime.UtcNow);
+        await registry.RegisterAsync(definition, metadata, CancellationToken.None);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(
+            async () => await registry.UpdateAsync("NumericMeasure", new MeasureValue("hello"), CancellationToken.None));
+        Assert.Contains("is not compatible with the registered measure", exception.Message);
+    }
+
+    [Fact]
+    public async Task Update_ThrowsExceptionForOutOfRangeValue()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+        var definition = new MeasureDefinition { Name = "RangedMeasure", Type = MeasureType.Number, Minimum = 0.0, Maximum = 100.0 };
+        var metadata = new MeasureMetadata(DateTime.UtcNow);
+        await registry.RegisterAsync(definition, metadata, CancellationToken.None);
+
+        // Act & Assert - Below minimum
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            async () => await registry.UpdateAsync("RangedMeasure", new MeasureValue(Length.FromMeters(-10.0)), CancellationToken.None));
+        Assert.Contains("is less than the registered minimum", exception.Message);
+
+        // Act & Assert - Above maximum
+        exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            async () => await registry.UpdateAsync("RangedMeasure", new MeasureValue(Length.FromMeters(110.0)), CancellationToken.None));
+        Assert.Contains("is greater than the registered maximum", exception.Message);
+    }
+
+    [Fact]
+    public async Task FindMethods_FlowsCorrectly()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+        var definition = new MeasureDefinition { Name = "MeasureToFind", Type = MeasureType.Number };
+        var metadata = new MeasureMetadata(DateTime.UtcNow);
+        await registry.RegisterAsync(definition, metadata, CancellationToken.None);
+
+        // Act - FindAsync
+        var foundMeasureAsync = await registry.FindAsync("MeasureToFind", CancellationToken.None);
+        Assert.NotNull(foundMeasureAsync);
+        Assert.Equal("MeasureToFind", foundMeasureAsync.Name);
+
+        // Act - FindAllAsync()
+        var allMeasures = await registry.FindAllAsync(CancellationToken.None);
+        Assert.Contains(allMeasures, m => m.Name == "MeasureToFind");
+
+        // Act - FindDefinition
+        var foundDefinition = registry.FindDefinition("MeasureToFind");
+        Assert.NotNull(foundDefinition);
+        Assert.Equal("MeasureToFind", foundDefinition.Name);
+
+        // Act - FindAllDefinitionsAsync()
+        var allDefinitions = await registry.FindAllDefinitionsAsync(CancellationToken.None);
+        Assert.Contains(allDefinitions, d => d.Name == "MeasureToFind");
+    }
+
+    [Fact]
+    public async Task RegisterMany_FindAllByName_FlowsCorrectly()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+
+        var measuresToRegister = new List<(MeasureDefinition Definition, MeasureMetadata Metadata)>
+        {
+            (new MeasureDefinition { Name = "Measure1", Type = MeasureType.Number }, new MeasureMetadata(DateTime.UtcNow)),
+            (new MeasureDefinition { Name = "Measure2", Type = MeasureType.String, QuantityType = "", Unit = "" }, new MeasureMetadata(DateTime.UtcNow)),
+            (new MeasureDefinition { Name = "Measure3", Type = MeasureType.Number }, new MeasureMetadata(DateTime.UtcNow))
+        };
+
+        // Act - RegisterManyAsync
+        await registry.RegisterManyAsync(measuresToRegister, CancellationToken.None);
+
+        // Act - FindAllAsync(names)
+        var foundMeasures = await registry.FindAllAsync(new[] { "Measure1", "Measure3" }, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, foundMeasures.Count());
+        Assert.Contains(foundMeasures, m => m.Name == "Measure1");
+        Assert.Contains(foundMeasures, m => m.Name == "Measure3");
+        Assert.DoesNotContain(foundMeasures, m => m.Name == "Measure2");
+
+        // Act - FindAllDefinitionsAsync(names)
+        var foundDefinitions = await registry.FindAllDefinitionsAsync(new[] { "Measure1", "Measure2" }, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, foundDefinitions.Count());
+        Assert.Contains(foundDefinitions, d => d.Name == "Measure1");
+        Assert.Contains(foundDefinitions, d => d.Name == "Measure2");
+        Assert.DoesNotContain(foundDefinitions, d => d.Name == "Measure3");
+    }
+
+    [Fact]
+    public async Task UpdateMany_FlowsCorrectly()
+    {
+        // Arrange
+        var storage = new InMemoryStorage();
+        var registry = new Registry(storage);
+
+        var measuresToRegister = new List<(MeasureDefinition Definition, MeasureMetadata Metadata)>
+        {
+            (new MeasureDefinition { Name = "MeasureA", Type = MeasureType.Number }, new MeasureMetadata(DateTime.UtcNow)),
+            (new MeasureDefinition { Name = "MeasureB", Type = MeasureType.String, QuantityType = "", Unit = "" }, new MeasureMetadata(DateTime.UtcNow))
+        };
+        await registry.RegisterManyAsync(measuresToRegister, CancellationToken.None);
+
+        // Act - UpdateManyAsync
+        var updates = new List<(string Name, MeasureValue Value)>
+        {
+            ("MeasureA", new MeasureValue(Length.FromMeters(123.45))),
+            ("MeasureB", new MeasureValue("new string value"))
+        };
+        await registry.UpdateManyAsync(updates, CancellationToken.None);
+
+        // Assert
+        var measureA = registry.Find("MeasureA");
+        var measureB = registry.Find("MeasureB");
+
+        Assert.NotNull(measureA);
+        Assert.NotNull(measureB);
+        Assert.Equal(new MeasureValue(Length.FromMeters(123.45)), measureA.Value);
+        Assert.Equal(new MeasureValue("new string value"), measureB.Value);
+    }
+}

--- a/Tests/Tinkwell.Measures.Tests/Tinkwell.Measures.Tests.csproj
+++ b/Tests/Tinkwell.Measures.Tests/Tinkwell.Measures.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="UnitsNet" Version="5.74.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Tinkwell.Measures\Tinkwell.Measures.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tinkwell.sln
+++ b/Tinkwell.sln
@@ -104,6 +104,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tinkwell.Actions.Configurat
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tinkwell.Bridge.MqttClient.Tests", "Tests\Tinkwell.Bridge.MqttClient.Tests\Tinkwell.Bridge.MqttClient.Tests.csproj", "{59546C08-25A8-42D7-A247-4303D386FD87}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tinkwell.Measures.Tests", "Tests\Tinkwell.Measures.Tests\Tinkwell.Measures.Tests.csproj", "{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -474,6 +476,18 @@ Global
 		{59546C08-25A8-42D7-A247-4303D386FD87}.Release|x64.Build.0 = Release|Any CPU
 		{59546C08-25A8-42D7-A247-4303D386FD87}.Release|x86.ActiveCfg = Release|Any CPU
 		{59546C08-25A8-42D7-A247-4303D386FD87}.Release|x86.Build.0 = Release|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Debug|x64.Build.0 = Debug|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Debug|x86.Build.0 = Debug|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Release|x64.ActiveCfg = Release|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Release|x64.Build.0 = Release|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Release|x86.ActiveCfg = Release|Any CPU
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -507,6 +521,7 @@ Global
 		{EF08279B-0B0E-2007-F68F-DE3657BCDD5D} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{7145AD1B-AB2D-F6B0-D1E6-916ABC17A6C8} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{59546C08-25A8-42D7-A247-4303D386FD87} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{E1B5BB2E-F6A2-76A6-F3F4-3B3568D3AF64} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C0934B28-6FF7-4875-BBB5-5041537BE9EB}


### PR DESCRIPTION
This is the last batch of tests. It tests `Tinkwell.Measures`. Everything else has too many dependencies to gRPC services and it's easier to test it with integration tests were we spin up the entire application.