### PR TITLE
Tests for Executor (issue #7)

### DIFF
--- a/Documentation/CLI.md
+++ b/Documentation/CLI.md
@@ -34,7 +34,7 @@ Timeout (in seconds) when waiting to estabilish a connection. You should never n
 
 ## Text Matching
 
-Tinkwell CLI supports flexible wildcard-based runner filtering using a syntax similar to shell-style globbing — not full Git pathspec and not regex, but powerful enough for targeted matching. Note that search/filtering is always case insensitive (whilst normal exact matching is always case sensitive).
+Tinkwell CLI supports flexible [wildcard](./Wildcards.md)-based filtering using a syntax similar to shell-style globbing — not full Git pathspec and not regex, but powerful enough for targeted matching. Note that search/filtering is always case insensitive (whilst normal exact matching is always case sensitive).
 
 ### Supported Wildcard Syntax
 
@@ -655,11 +655,11 @@ You can use this command to create _trace files_ containing a set of predefined 
 ```bash
 # User will be prompted to answer all the questions from this meta-template
 # but we are not going to generate anything locally: we're interested in the answers
-tw templates meta_template_example --trace ./meta_trace.json --dry-run
+tw templates use meta_template_example --trace ./meta_trace.json --dry-run
 
 # Now you can distribute meta_trace.json and you can use it to always generate
 # the same configuration anywhere
-tw templates meta_template_example --input ./meta_trace.json
+tw templates use meta_template_example --input ./meta_trace.json
 ```
 
 ### ARGUMENTS

--- a/Documentation/Wildcards.md
+++ b/Documentation/Wildcards.md
@@ -6,6 +6,15 @@ These patterns are "git-like" and are converted into regular expressions for mat
 
 ## Supported Syntax
 
+| Pattern       | Meaning                                                   |
+|---------------|-----------------------------------------------------------|
+| `*`           | Matches any sequence of characters (including none)       |
+| `?`           | Matches exactly one character                             |
+| `[abc]`       | Matches a single character: `a`, `b`, or `c`              |
+| `[^abc]`      | Matches any character **except** `a`, `b`, or `c`         |
+| `[a-z]`       | Matches a single character in the given range             |
+
+
 Unless otherwise noted pattern matching is always **case-insensitive** and matchin is always performed using a neutral culture (`en-US`):
 
 *   The pattern `foo` will match `foo`, `FOO`, `Foo`.

--- a/Tests/Tinkwell.Actions.Executor.Tests/AgentFactoryTests.cs
+++ b/Tests/Tinkwell.Actions.Executor.Tests/AgentFactoryTests.cs
@@ -1,0 +1,93 @@
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Tinkwell.Actions.Configuration.Parser;
+
+namespace Tinkwell.Actions.Executor.Tests;
+
+public class AgentFactoryTests
+{
+    [Fact]
+    public void Create_WithValidIntent_CreatesAgentAndSetsProperties()
+    {
+        // Arrange
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var factory = new AgentFactory();
+        var intent = new Intent
+        {
+            Listener = new Listener { Id = "1", Topic = "test", Directives = new() },
+            Event = new Intent.EventInfo { Id = "1", Topic = "test", Subject = "s", Verb = "v", Object = "o" },
+            Directive = new Directive
+            {
+                AgentType = typeof(MockAgent),
+                Parameters = new Dictionary<string, object>
+                {
+                    { "message", "Hello" },
+                    { "value", 123 }
+                }
+            },
+            Payload = "{}"
+        };
+
+        // Act
+        var agent = factory.Create(serviceProvider, intent) as MockAgent;
+
+        // Assert
+        Assert.NotNull(agent);
+        var settings = agent.Settings as MockAgent.MockAgentSettings;
+        Assert.NotNull(settings);
+        Assert.Equal("Hello", settings.Message);
+        Assert.Equal(123, settings.Value);
+    }
+
+    [Fact]
+    public void Create_WithPayload_ComposesProperties()
+    {
+        // Arrange
+        var serviceProvider = new ServiceCollection().BuildServiceProvider();
+        var factory = new AgentFactory();
+        var intent = new Intent
+        {
+            Listener = new Listener { Id = "1", Topic = "test", Directives = new() },
+            Event = new Intent.EventInfo { Id = "1", Topic = "test", Subject = "s", Verb = "v", Object = "o" },
+            Directive = new Directive
+            {
+                AgentType = typeof(MockAgent),
+                Parameters = new Dictionary<string, object>
+                {
+                    { "message", new ActionPropertyString(ActionPropertyStringKind.Template, "Hello {{ payload.name }}") },
+                }
+            },
+            Payload = JsonSerializer.Serialize(new { name = "World" })
+        };
+
+        // Act
+        var agent = factory.Create(serviceProvider, intent) as MockAgent;
+
+        // Assert
+        Assert.NotNull(agent);
+        var settings = agent.Settings as MockAgent.MockAgentSettings;
+        Assert.NotNull(settings);
+        Assert.Equal("Hello World", settings.Message);
+    }
+}
+
+[Agent("mock")]
+public class MockAgent : IAgent
+{
+    public object? Settings => _settings;
+    private readonly MockAgentSettings _settings = new();
+
+    public Task ExecuteAsync(CancellationToken cancellationToken)
+    {
+        return Task.CompletedTask;
+    }
+
+    public class MockAgentSettings
+    {
+        [AgentProperty("message")]
+        public string Message { get; set; } = "";
+
+        [AgentProperty("value")]
+        public int Value { get; set; }
+    }
+}

--- a/Tests/Tinkwell.Actions.Executor.Tests/AgentFactoryTests.cs
+++ b/Tests/Tinkwell.Actions.Executor.Tests/AgentFactoryTests.cs
@@ -72,15 +72,13 @@ public class AgentFactoryTests
 }
 
 [Agent("mock")]
-public class MockAgent : IAgent
+public sealed class MockAgent : IAgent
 {
     public object? Settings => _settings;
     private readonly MockAgentSettings _settings = new();
 
     public Task ExecuteAsync(CancellationToken cancellationToken)
-    {
-        return Task.CompletedTask;
-    }
+        => Task.CompletedTask;
 
     public class MockAgentSettings
     {

--- a/Tests/Tinkwell.Actions.Executor.Tests/ExecutorTests.cs
+++ b/Tests/Tinkwell.Actions.Executor.Tests/ExecutorTests.cs
@@ -1,0 +1,93 @@
+using Microsoft.Extensions.Logging;
+using Tinkwell.Actions.Configuration.Parser;
+using Tinkwell.Services;
+using Tinkwell.TestHelpers;
+
+namespace Tinkwell.Actions.Executor.Tests;
+
+public class ExecutorTests
+{
+    public ExecutorTests()
+    {
+        AgentsRecruiter.RegisterAssembly(typeof(ExecutorTests).Assembly);
+    }
+
+    [Fact]
+    public async Task StartAsync_WithValidConfig_SubscribesToCorrectEvents()
+    {
+        // Arrange
+        var eventsGateway = new MockEventsGateway();
+        var dispatcher = new MockIntentDispatcher();
+        var logger = new LoggerFactory().CreateLogger<Executor>();
+        var fileReader = new MockTwaFileReader(
+            new WhenDefinition
+            {
+                Topic = "topic1",
+                Actions = new[] { new ActionDefinition("mock", new Dictionary<string, object>()) }.ToList()
+            },
+            new WhenDefinition
+            {
+                Topic = "topic2",
+                Subject = "subject2",
+                Actions = new[] { new ActionDefinition("mock", new Dictionary<string, object>()) }.ToList()
+            }
+        );
+        var options = new ExecutorOptions { Path = "fake.twa" };
+        var executor = new Executor(logger, eventsGateway, fileReader, dispatcher, options);
+
+        // Act
+        await executor.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        // Assert
+        Assert.Equal(1, eventsGateway.Subscribers);
+    }
+
+    [Fact]
+    public async Task OnEventReceived_WithMatchingListener_DispatchesCorrectIntent()
+    {
+        // Arrange
+        var eventsGateway = new MockEventsGateway();
+        var dispatcher = new MockIntentDispatcher();
+        var logger = new LoggerFactory().CreateLogger<Executor>();
+        var fileReader = new MockTwaFileReader(
+            new WhenDefinition
+            {
+                Topic = "test-topic",
+                Actions = new[] { new ActionDefinition("mock", new Dictionary<string, object>()) }.ToList()
+            }
+        );
+        var options = new ExecutorOptions { Path = "fake.twa" };
+        var executor = new Executor(logger, eventsGateway, fileReader, dispatcher, options);
+        await executor.StartAsync(CancellationToken.None);
+        await Task.Delay(100);
+
+        var eventToSend = new PublishEventsRequest
+        {
+            Topic = "test-topic",
+            Payload = "{\"key\":\"value\"}"
+        };
+
+        // Act
+        await eventsGateway.PublishAsync(eventToSend, CancellationToken.None);
+        await Task.Delay(100);
+
+        // Assert
+        Assert.Single(dispatcher.Intents);
+        var intent = dispatcher.Intents[0];
+        Assert.Equal("test-topic", intent.Event.Topic);
+        Assert.Equal("{\"key\":\"value\"}", intent.Payload);
+        Assert.Equal(typeof(MockAgent), intent.Directive.AgentType);
+    }
+}
+
+file sealed class MockIntentDispatcher : IIntentDispatcher
+{
+    public List<Intent> Intents { get; } = new();
+
+    public Task DispatchAsync(Intent intent, CancellationToken cancellationToken)
+    { 
+        Intents.Add(intent);
+        return Task.CompletedTask;
+    }
+}

--- a/Tests/Tinkwell.Actions.Executor.Tests/Tinkwell.Actions.Executor.Tests.csproj
+++ b/Tests/Tinkwell.Actions.Executor.Tests/Tinkwell.Actions.Executor.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Tinkwell.Actions.Executor\Tinkwell.Actions.Executor.csproj" />
+    <ProjectReference Include="..\Tinkwell.TestHelpers\Tinkwell.TestHelpers.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Tinkwell.TestHelpers/MockTwaFileReader.cs
+++ b/Tests/Tinkwell.TestHelpers/MockTwaFileReader.cs
@@ -1,0 +1,24 @@
+using Tinkwell.Actions.Configuration.Parser;
+using Tinkwell.Bootstrapper.Ensamble;
+
+namespace Tinkwell.TestHelpers;
+
+public sealed class MockTwaFile : ITwaFile
+{
+    public IEnumerable<WhenDefinition> Listeners { get; init; } = new List<WhenDefinition>();
+}
+
+public sealed class MockTwaFileReader : IConfigFileReader<ITwaFile>
+{
+    private readonly MockTwaFile _file = new();
+
+    public MockTwaFileReader(params WhenDefinition[] listeners)
+    {
+        _file = new MockTwaFile { Listeners = listeners.ToList() };
+    }
+
+    public Task<ITwaFile> ReadAsync(string path, FileReaderOptions options, CancellationToken cancellationToken)
+    {
+        return Task.FromResult<ITwaFile>(_file);
+    }
+}

--- a/Tests/Tinkwell.TestHelpers/Tinkwell.TestHelpers.csproj
+++ b/Tests/Tinkwell.TestHelpers/Tinkwell.TestHelpers.csproj
@@ -4,6 +4,7 @@
     <ProjectReference Include="..\..\Tinkwell.Measures.Configuration.Parser\Tinkwell.Measures.Configuration.Parser.csproj" />
     <ProjectReference Include="..\..\Tinkwell.Measures\Tinkwell.Measures.csproj" />
     <ProjectReference Include="..\..\Tinkwell.Services.Proto\Tinkwell.Services.Proto.csproj" />
+    <ProjectReference Include="..\..\Tinkwell.Actions.Configuration.Parser\Tinkwell.Actions.Configuration.Parser.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Tinkwell.Actions.Executor/AgentAttribute.cs
+++ b/Tinkwell.Actions.Executor/AgentAttribute.cs
@@ -7,5 +7,8 @@
 [AttributeUsage(AttributeTargets.Class)]
 public sealed class AgentAttribute(string name) : Attribute
 {
+    /// <summary>
+    /// Gets the name of the agent (as seen from the configuration file).
+    /// </summary>
     public string Name { get; } = name;
 }

--- a/Tinkwell.Actions.Executor/AgentPropertyAttribute.cs
+++ b/Tinkwell.Actions.Executor/AgentPropertyAttribute.cs
@@ -4,7 +4,11 @@
 /// Provides an attribute to mark properties of agents that should be populated
 /// with values from the configuration.
 /// </summary>
+[AttributeUsage(AttributeTargets.Property)]
 public sealed class AgentPropertyAttribute(string name) : Attribute
 {
+    /// <summary>
+    /// Gets the name of the property, as seen from the configuration file.
+    /// </summary>
     public string Name { get; } = name;
 }

--- a/Tinkwell.Actions.Executor/IIntentDispatcher.cs
+++ b/Tinkwell.Actions.Executor/IIntentDispatcher.cs
@@ -1,0 +1,6 @@
+﻿namespace Tinkwell.Actions.Executor;
+
+internal interface IIntentDispatcher
+{
+    Task DispatchAsync(Intent intent, CancellationToken cancellationToken);
+}

--- a/Tinkwell.Actions.Executor/IntentDispatcher.cs
+++ b/Tinkwell.Actions.Executor/IntentDispatcher.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Tinkwell.Actions.Executor;
+
+sealed class IntentDispatcher(IServiceProvider serviceProvider, ILogger<IntentDispatcher> logger, AgentFactory factory) : IIntentDispatcher
+{
+    public async Task DispatchAsync(Intent intent, CancellationToken cancellationToken)
+    {
+        try
+        {
+            IAgent? agent = null;
+            try
+            {
+                agent = _factory.Create(_serviceProvider, intent);
+            }
+            catch (ExecutorException e)
+            {
+                _logger.LogError(e, "Disabling listener because it failed to create agent for intent '{IntentId}': {Message}.", intent.Event.Id, e.Message);
+                intent.Listener.Enabled = false;
+            }
+
+            if (agent is not null)
+                await agent.ExecuteAsync(cancellationToken);
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "An unexpected error occurred while executing the intent '{IntentId}': {Message}.", intent.Event.Id, e.Message);
+        }
+    }
+
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+    private readonly ILogger<IntentDispatcher> _logger = logger;
+    private readonly AgentFactory _factory = factory;
+}

--- a/Tinkwell.Actions.Executor/README.md
+++ b/Tinkwell.Actions.Executor/README.md
@@ -37,6 +37,7 @@ graph TD
     INT(Intent):::data
     Q([Queue]):::data
     W(Worker):::runtime
+    D(Dispatcher):::runtime
     A(Agent):::runtime
 
     TWA -- "1 reads" --> EX
@@ -49,7 +50,8 @@ graph TD
     EX -- "7 creates intent (directive + payload)" --> INT
     INT -- "8 enqueues" --> Q
     W -- "9 dequeues" --> Q
-    W -- "10 executes" --> A
+    W -- "10 dispatches" --> D
+    D -- "11 executes" --> A
 
     linkStyle 0 stroke:cornflowerblue,stroke-width:1.5px,color:cornflowerblue;
     linkStyle 1 stroke:cornflowerblue,stroke-width:1.5px,color:cornflowerblue;

--- a/Tinkwell.Actions.Executor/Registrar.cs
+++ b/Tinkwell.Actions.Executor/Registrar.cs
@@ -2,6 +2,7 @@
 using Tinkwell.Actions.Configuration.Parser;
 using Tinkwell.Bootstrapper.Ensamble;
 using Tinkwell.Bootstrapper.Hosting;
+using Tinkwell.Services.Proto.Proxies;
 
 namespace Tinkwell.Actions.Executor;
 
@@ -20,6 +21,8 @@ public sealed class Registrar : IHostedDllRegistrar
             services.AddSingleton<Executor>();
             services.AddTransient<IConfigFileReader<ITwaFile>, TwaFileReader>();
             services.AddTransient<ServiceLocator>();
+            services.AddTransient<IIntentDispatcher, IntentDispatcher>();
+            services.AddTransient<IEventsGateway, EventsGatewayProxy>();
         });
     }
 }

--- a/Tinkwell.Actions.Executor/Tinkwell.Actions.Executor.csproj
+++ b/Tinkwell.Actions.Executor/Tinkwell.Actions.Executor.csproj
@@ -22,4 +22,8 @@
 	  <ProjectReference Include="..\Tinkwell.Services.Proto\Tinkwell.Services.Proto.csproj" />
 	</ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Tinkwell.Actions.Executor.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/Tinkwell.Bridge.MqttClient/MqttClientBridge.cs
+++ b/Tinkwell.Bridge.MqttClient/MqttClientBridge.cs
@@ -158,16 +158,11 @@ sealed class MqttClientBridge : IAsyncDisposable
         Debug.Assert(_mqttClient is not null);
         Debug.Assert(_clientOptions is not null);
 
+        _logger.LogWarning("MQTT client disconnected from broker. Reason: {Reason}", e.Reason);
         if (CanReconnect())
         {
-            _logger.LogWarning("MQTT client disconnected from broker. Reason: {Reason}", e.Reason);
             await Task.Delay(_options.RetryDelayInMilliseconds, CancellationToken.None);
             await ConnectAsync(CancellationToken.None);
-        }
-        else
-        {
-            _logger.LogError("MQTT client disconnected from broker. Reason: {Reason}. Reconnection is not allowed.",
-                e.Reason);
         }
 
         bool CanReconnect()

--- a/Tinkwell.Services.Proto/Proxies/EventsGatewayProxy.cs
+++ b/Tinkwell.Services.Proto/Proxies/EventsGatewayProxy.cs
@@ -3,6 +3,7 @@
 /// <summary>
 /// Implement <see cref="IEventsGateway"/>, a simplified interface for the Events Gateway service.
 /// </summary>
+
 public sealed class EventsGatewayProxy(ServiceLocator locator) : IEventsGateway
 {
     /// <inheritdocs />

--- a/Tinkwell.sln
+++ b/Tinkwell.sln
@@ -116,6 +116,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tinkwell.TestHelpers", "Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tinkwell.Reactor.Tests", "Tests\Tinkwell.Reactor.Tests\Tinkwell.Reactor.Tests.csproj", "{AE04631E-6820-437D-A23D-B050E8EF5838}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tinkwell.Actions.Executor.Tests", "Tests\Tinkwell.Actions.Executor.Tests\Tinkwell.Actions.Executor.Tests.csproj", "{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -546,6 +548,18 @@ Global
 		{AE04631E-6820-437D-A23D-B050E8EF5838}.Release|x64.Build.0 = Release|Any CPU
 		{AE04631E-6820-437D-A23D-B050E8EF5838}.Release|x86.ActiveCfg = Release|Any CPU
 		{AE04631E-6820-437D-A23D-B050E8EF5838}.Release|x86.Build.0 = Release|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Debug|x64.Build.0 = Debug|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Debug|x86.Build.0 = Debug|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Release|x64.ActiveCfg = Release|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Release|x64.Build.0 = Release|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Release|x86.ActiveCfg = Release|Any CPU
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -585,6 +599,7 @@ Global
 		{A2E91DD1-A93C-4E18-95EC-09B7980FF158} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{DA850829-C513-4780-B08C-476B37279D81} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{AE04631E-6820-437D-A23D-B050E8EF5838} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{BDDFEA3E-A17D-4D3C-907D-7298A7B96656} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C0934B28-6FF7-4875-BBB5-5041537BE9EB}


### PR DESCRIPTION
Linked to https://github.com/arepetti/Tinkwell/issues/7 , it's needed for https://github.com/arepetti/Tinkwell/issues/14

Unit tests for Executor logic (using the new gRPC proxies introduced for unit testing the Reducer.