### PR TITLE
Workflow to publish Tinkwell.Bootstrapper as NuGet package when released

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,44 @@
+name: Publish Tinkwell.Bootstrapper to NuGet
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-pack:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.x'
+
+    - name: Restore dependencies
+      run: |
+        dotnet restore ./Source/Tinkwell.Bootstrapper/Tinkwell.Bootstrapper.csproj
+        dotnet restore ./Source/Tests/Tinkwell.Bootstrapper.Tests/Tinkwell.Bootstrapper.Tests.csproj
+
+    - name: Build library
+      run: dotnet build ./Source/Tinkwell.Bootstrapper/Tinkwell.Bootstrapper.csproj --configuration Release --no-restore
+
+    - name: Build tests
+      run: dotnet build ./Source/Tests/Tinkwell.Bootstrapper.Tests/Tinkwell.Bootstrapper.Tests.csproj --configuration Release --no-restore
+
+    - name: Run tests
+      run: dotnet test ./Source/Tests/Tinkwell.Bootstrapper.Tests/Tinkwell.Bootstrapper.Tests.csproj --no-build --configuration Release --verbosity normal --filter Category!=CI-Disabled
+
+    - name: Pack library
+      run: dotnet pack ./Source/Tinkwell.Bootstrapper/Tinkwell.Bootstrapper.csproj --configuration Release --no-build --output ./nupkgs
+
+    - name: Upload NuGet package as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: Tinkwell.Bootstrapper-nuget
+        path: ./nupkgs/*.nupkg
+
+    - name: Push to NuGet
+      run: dotnet nuget push ./nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/Source/Tinkwell.Bootstrapper.Ensamble.Parser/EnsamblePreprocessor.cs
+++ b/Source/Tinkwell.Bootstrapper.Ensamble.Parser/EnsamblePreprocessor.cs
@@ -36,7 +36,7 @@ static class EnsamblePreprocessor
                 .Replace("{{ properties }}", properties)
                 .Replace("{{ host.grpc }}", WellKnownNames.DefaultGrpcHostAssembly)
                 .Replace("{{ host.dll }}", WellKnownNames.DefaultDllHostAssembly)
-                .Replace("{{ firmlet.health_check }}", WellKnownNames.DefaaultHealthCheckService)
+                .Replace("{{ firmlet.health_check }}", WellKnownNames.DefaultHealthCheckService)
                 .Replace("{{ address.supervisor }}", WellKnownNames.SupervisorCommandServerPipeName);
         }
         catch (FileNotFoundException e)

--- a/Source/Tinkwell.Bootstrapper/Ensamble/EnsambleConditionEvaluator.cs
+++ b/Source/Tinkwell.Bootstrapper/Ensamble/EnsambleConditionEvaluator.cs
@@ -75,7 +75,7 @@ public sealed class EnsambleConditionEvaluator : IEnsambleConditionEvaluator
     private bool IsDevelopmentEnvironment()
     {
         // Forced by configuration option or environment variable.
-        // If this is present the we honor whatever value there is.
+        // If this is present then we honor whatever value there is.
         var environment = _configuration?.GetValue<string>("Ensamble:Environment")
             ?? Environment.GetEnvironmentVariable(WellKnownNames.EnvironmentEnvironmentVariable);
 

--- a/Source/Tinkwell.Bootstrapper/Ensamble/FileReaderOptions.cs
+++ b/Source/Tinkwell.Bootstrapper/Ensamble/FileReaderOptions.cs
@@ -3,6 +3,10 @@
 /// <summary>
 /// Represents options for reading configuration files, such as whether to apply filtering.
 /// </summary>
+/// <param name="Unfiltered">
+/// Indicates whether the list returned by the reader should be filtered. It only applies for
+/// configuration files where the content supports conditional loading.
+/// </param>
 public record FileReaderOptions(bool Unfiltered)
 {
     /// <summary>

--- a/Source/Tinkwell.Bootstrapper/Expressions/IExpressionEvaluator.cs
+++ b/Source/Tinkwell.Bootstrapper/Expressions/IExpressionEvaluator.cs
@@ -1,8 +1,68 @@
 ﻿namespace Tinkwell.Bootstrapper.Expressions;
 
+/// <summary>
+/// Represents an expression evaluator.
+/// </summary>
 public interface IExpressionEvaluator
 {
+    /// <summary>
+    /// Evaluates the specified expression.
+    /// </summary>
+    /// <param name="expression">The expression to evaluate.</param>
+    /// <param name="parameters">
+    /// Parameters for the expression. It could be an object or a dictionary.
+    /// </param>
+    /// <returns>
+    /// The result returned by the specified expression.
+    /// </returns>
+    /// <exception cref="BootstrapperException">
+    /// If the expression is invalid or it's using unknown parameters or functions.
+    /// </exception>
     object? Evaluate(string expression, object? parameters);
+
+    /// <summary>
+    /// Evaluates the specified expression as boolean.
+    /// </summary>
+    /// <param name="expression">The expression to evaluate.</param>
+    /// <param name="parameters">
+    /// Parameters for the expression. It could be an object or a dictionary.
+    /// </param>
+    /// <returns>
+    /// The result returned by the specified expression. If it's not a boolean then
+    /// it's converted.
+    /// </returns>
+    /// <exception cref="BootstrapperException">
+    /// <para>
+    /// If the expression is invalid or it's using unknown parameters or functions.
+    /// </para>
+    /// <para>-or-</para>
+    /// <para>
+    /// The value returned by the expression is not <c>bool</c> and it cannot be
+    /// converted to a boolean value.
+    /// </para>
+    /// </exception>
     bool EvaluateBool(string expression, object? parameters);
+
+    /// <summary>
+    /// Evaluates the specified expression as string.
+    /// </summary>
+    /// <param name="expression">The expression to evaluate.</param>
+    /// <param name="parameters">
+    /// Parameters for the expression. It could be an object or a dictionary.
+    /// </param>
+    /// <returns>
+    /// The result returned by the specified expression. If it's not a string then it's
+    /// converted, using the invariant culture as formatter.
+    /// </returns>
+    /// <exception cref="BootstrapperException">
+    /// <para>
+    /// If the expression is invalid or it's using unknown parameters or functions.
+    /// </para>
+    /// <para>-or-</para>
+    /// <para>
+    /// The value returned by the expression is not <c>string</c> and it cannot be
+    /// converted to a string value.
+    /// </para>
+    /// </exception>
     string EvaluateString(string expression, object? parameters);
 }

--- a/Source/Tinkwell.Bootstrapper/Hosting/IGrpcServerHost.cs
+++ b/Source/Tinkwell.Bootstrapper/Hosting/IGrpcServerHost.cs
@@ -5,5 +5,13 @@
 /// </summary>
 public interface IGrpcServerHost : IConfigurableHost
 {
+    /// <summary>
+    /// Maps the specified service to the web server exposed by the host.
+    /// </summary>
+    /// <typeparam name="TService">The gRPC service you want to expose.</typeparam>
+    /// <param name="definition">
+    /// An optional definition of the service you want to expose (for example to configure
+    /// friendly name, family name or aliases).
+    /// </param>
     void MapGrpcService<TService>(ServiceDefinition? definition = default) where TService : class;
 }

--- a/Source/Tinkwell.Bootstrapper/Ipc/INamedPipeServerFactory.cs
+++ b/Source/Tinkwell.Bootstrapper/Ipc/INamedPipeServerFactory.cs
@@ -1,7 +1,16 @@
 ﻿
 namespace Tinkwell.Bootstrapper.Ipc;
 
+/// <summary>
+/// Represent a factory for <see cref="INamedPipeServer"/> instances.
+/// </summary>
 public interface INamedPipeServerFactory
 {
+    /// <summary>
+    /// Creates a  new instance of <see cref="INamedPipeServer"/>.
+    /// </summary>
+    /// <returns>
+    /// A new instance of <c>INamedPipeServer</c>.
+    /// </returns>
     INamedPipeServer Create();
 }

--- a/Source/Tinkwell.Bootstrapper/Ipc/NamedPipeServer.cs
+++ b/Source/Tinkwell.Bootstrapper/Ipc/NamedPipeServer.cs
@@ -14,19 +14,19 @@ public sealed class NamedPipeServer : INamedPipeServer
     /// </summary>
     public static readonly int DefaultMaxConcurrentConnections = 4;
 
-    /// <inheritsdocs />
+    /// <inheritdoc />
     public int MaxConcurrentConnections { get; set; } = DefaultMaxConcurrentConnections;
 
-    /// <inheritsdocs />
+    /// <inheritdoc />
     public event EventHandler? Connected;
 
-    /// <inheritsdocs />
+    /// <inheritdoc />
     public event EventHandler? Disconnected;
 
-    /// <inheritsdocs />
+    /// <inheritdoc />
     public ProcessPipeDataDelegate? ProcessAsync {  get; set; }
 
-    /// <inheritsdocs />
+    /// <inheritdoc />
     public void Open(string pipeName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(pipeName);
@@ -40,7 +40,7 @@ public sealed class NamedPipeServer : INamedPipeServer
         CreatePipe();
     }
 
-    /// <inheritsdocs />
+    /// <inheritdoc />
     public void Close()
     {
         if (!IsOpen)

--- a/Source/Tinkwell.Bootstrapper/Ipc/NamedPipeServerErrorEventArgs.cs
+++ b/Source/Tinkwell.Bootstrapper/Ipc/NamedPipeServerErrorEventArgs.cs
@@ -1,6 +1,6 @@
 ﻿namespace Tinkwell.Bootstrapper.Ipc;
 
-public sealed class NamedPipeServerErrorEventArgs(Exception exception) : EventArgs
+sealed class NamedPipeServerErrorEventArgs(Exception exception) : EventArgs
 {
     public Exception Exception { get; } = exception;
 }

--- a/Source/Tinkwell.Bootstrapper/Ipc/WellKnownNames.cs
+++ b/Source/Tinkwell.Bootstrapper/Ipc/WellKnownNames.cs
@@ -43,6 +43,7 @@ public static class WellKnownNames
     public static readonly string SupervisorPidEnvironmentVariable = "TINKWELL_SUPERVISOR_PID";
 
     /// <summary>
+    /// <strong>Internal</strong>. Use <c>HostingInformation</c> instead.
     /// An optional environment variable that contains the <em>environment</em> for this
     /// installation. It could be <c>"Development"</c> or <c>"Release"</c>.
     /// <c>TINKWELL_ENVIRONMENT</c>.
@@ -56,7 +57,7 @@ public static class WellKnownNames
     /// <c>TINKWELL_WORKING_DIR_PATH</c>.
     /// </summary>
     /// <remarks>
-    /// Do not use this variable directly, obtain the value from
+    /// <strong>Internal</strong>: do not use this variable directly, obtain the value from
     /// <see cref="Hosting.HostingInformation.WorkingDirectory"/>.
     /// </remarks>
     public static readonly string WorkingDirectoryEnvironmentVariable = "TINKWELL_WORKING_DIR_PATH";
@@ -68,7 +69,7 @@ public static class WellKnownNames
     /// <c>TINKWELL_APP_DATA_PATH</c>.
     /// </summary>
     /// <remarks>
-    /// Do not use this variable directly, obtain the value from
+    /// <strong>Internal</strong>: do not use this variable directly, obtain the value from
     /// <see cref="Hosting.HostingInformation.ApplicationDataDirectory"/>.
     /// </remarks>
     public static readonly string AppDataEnvironmentVariable = "TINKWELL_APP_DATA_PATH";
@@ -80,13 +81,13 @@ public static class WellKnownNames
     /// <c>TINKWELL_USER_DATA_PATH</c>.
     /// </summary>
     /// <remarks>
-    /// Do not use this variable directly, obtain the value from
+    /// <strong>Internal</strong>: do not use this variable directly, obtain the value from
     /// <see cref="Hosting.HostingInformation.UserDataDirectory"/>.
     /// </remarks>
     public static readonly string UserDataEnvironmentVariable = "TINKWELL_USER_DATA_PATH";
 
     /// <summary>
-    /// <strong>Internal</strong>. If possible try to use <c>ServiceLocator</c>.
+    /// <strong>Caution</strong>. If possible try to use <c>ServiceLocator</c>.
     /// <para>
     /// The environment variable for the client certificate for gRPC HTTPS calls.
     /// </para>
@@ -95,7 +96,7 @@ public static class WellKnownNames
     public static readonly string ClientCertificatePath = "TINKWELL_CLIENT_CERT_PATH";
 
     /// <summary>
-    /// <strong>Internal</strong>. If possible try to use an existing host.
+    /// <strong>Caution</strong>. If possible try to use an existing host.
     /// <para>
     /// The environment variable for the web server certificate path.
     /// </para>
@@ -104,7 +105,7 @@ public static class WellKnownNames
     public static readonly string WebServerCertificatePath = "TINKWELL_CERT_PATH";
 
     /// <summary>
-    /// <strong>Internal</strong>. If possible try to use an existing host.
+    /// <strong>Caution</strong>. If possible try to use an existing host.
     /// <para>
     /// The environment variable for the web server certificate password.
     /// </para>
@@ -113,7 +114,7 @@ public static class WellKnownNames
     public static readonly string WebServerCertificatePass = "TINKWELL_CERT_PASS";
 
     /// <summary>
-    /// <strong>Internal, do not use.</strong>.
+    /// <strong>Internal, do not use</strong>.
     /// <para>
     /// The default assembly name for the gRPC host.
     /// </para>
@@ -122,7 +123,7 @@ public static class WellKnownNames
     public static readonly string DefaultGrpcHostAssembly = "Tinkwell.Bootstrapper.GrpcHost";
 
     /// <summary>
-    /// <strong>Internal, do not use.</strong>.
+    /// <strong>Internal, do not use</strong>.
     /// <para>
     /// The default assembly name for the DLL host.
     /// </para>
@@ -131,13 +132,13 @@ public static class WellKnownNames
     public static readonly string DefaultDllHostAssembly = "Tinkwell.Bootstrapper.DllHost";
 
     /// <summary>
-    /// <strong>Internal, do not use.</strong>.
+    /// <strong>Internal, do not use</strong>.
     /// <para>
     /// The default health check service DLL name.
     /// </para>
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static readonly string DefaaultHealthCheckService = "Tinkwell.HealthCheck.dll";
+    public static readonly string DefaultHealthCheckService = "Tinkwell.HealthCheck.dll";
 
     /// <summary>
     /// The event topic name for signals.

--- a/Source/Tinkwell.Bootstrapper/NuGet/README.md
+++ b/Source/Tinkwell.Bootstrapper/NuGet/README.md
@@ -1,0 +1,5 @@
+This library provides common types and interfaces needed to integrate your own runners in Tinkwell.
+
+Please refer to the [product documentation](https://github.com/arepetti/Tinkwell/tree/master/Documentation) for details and examples.
+
+Happy tinkering!

--- a/Source/Tinkwell.Bootstrapper/ObjectJsonConverter.cs
+++ b/Source/Tinkwell.Bootstrapper/ObjectJsonConverter.cs
@@ -3,8 +3,14 @@ using System.Text.Json.Serialization;
 
 namespace Tinkwell;
 
+/// <summary>
+/// Special converter for <see cref="JsonSerializer"/> to workaround its default behaviour:
+/// when deserializing a dictionary <c>(Dictionary{string, object}</c> as <c>object</c> it simply
+/// returns the raw <c>JsonElement</c>. This converter changes that and returns a dictionary as expected.
+/// </summary>
 public sealed class ObjectJsonConverter : JsonConverter<object>
 {
+    /// <inheritedocs />
     public override object Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         return reader.TokenType switch
@@ -20,6 +26,7 @@ public sealed class ObjectJsonConverter : JsonConverter<object>
         };
     }
 
+    /// <inheritedocs />
     public override void Write(Utf8JsonWriter writer, object value, JsonSerializerOptions options)
         => JsonSerializer.Serialize(writer, value, value?.GetType() ?? typeof(object), options);
 

--- a/Source/Tinkwell.Bootstrapper/StrategyAssemblyLoader.cs
+++ b/Source/Tinkwell.Bootstrapper/StrategyAssemblyLoader.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 namespace Tinkwell.Bootstrapper;
 
 /// <summary>
-/// Loads strategy assemblies based on a specified root namespac and task name.
+/// Loads strategy assemblies based on a specified root namespace and task name.
 /// </summary>
 public static class StrategyAssemblyLoader
 {
@@ -217,7 +217,7 @@ public static class StrategyAssemblyLoader
     /// Determines the string comparer to use when working with file system entries
     /// in the specified path.
     /// </summary>
-    /// <param name="path"></param>
+    /// <param name="path">Path to an existing directory or file.</param>
     /// <returns>A <c>StringComparison</c>.</returns>
     /// <remarks>
     /// This function always uses an <strong>ordinal</strong> string comparer, case-sensitive or not

--- a/Source/Tinkwell.Bootstrapper/Tinkwell.Bootstrapper.csproj
+++ b/Source/Tinkwell.Bootstrapper/Tinkwell.Bootstrapper.csproj
@@ -1,20 +1,41 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-	<PropertyGroup>
-		<OutputPath>$(SolutionDir)build\</OutputPath>
-		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-	</PropertyGroup>
-	<ItemGroup>
-	  <PackageReference Include="Fluid.Core" Version="2.24.0" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
-	  <PackageReference Include="NCalcSync" Version="5.4.2" />
-	  <PackageReference Include="Superpower" Version="3.1.0" />
-	</ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+    <PropertyGroup>
+        <OutputPath>$(SolutionDir)build\</OutputPath>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <PackageId>Tinkwell.Bootstrapper</PackageId>
+        <Authors>Adriano Repetti</Authors>
+        <Description>Integration with Tinkwell.</Description>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/arepetti/Tinkwell</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/arepetti/Tinkwell</RepositoryUrl>
+        <Keyword>Tinkwell</Keyword>
+        <Keyword>Firmware-less</Keyword>
+        <Keyword>Firmwareless</Keyword>
+        <Keyword>Runner</Keyword>
+        <PackageReadmeFile>NuGet/README.md</PackageReadmeFile>
+    </PropertyGroup>
+    <ItemGroup>
+        <Folder Include="NuGet\" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Include="NuGet/README.md" Pack="true" PackagePath="" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Fluid.Core" Version="2.24.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.6" />
+        <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.6" />
+        <PackageReference Include="NCalcSync" Version="5.4.2" />
+        <PackageReference Include="Superpower" Version="3.1.0" />
+    </ItemGroup>
 </Project>

--- a/Source/Tinkwell.Measures.Configuration.Parser/TwmFileReader.cs
+++ b/Source/Tinkwell.Measures.Configuration.Parser/TwmFileReader.cs
@@ -7,7 +7,7 @@ namespace Tinkwell.Measures.Configuration.Parser;
 /// </summary>
 public sealed class TwmFileReader : IConfigFileReader<ITwmFile>
 {
-    /// <inheritdocs />
+    /// <inheritdoc />
     public async Task<ITwmFile> ReadAsync(string path, FileReaderOptions options, CancellationToken cancellationToken)
     {
         var file = new TwmFile();

--- a/Source/Tinkwell.Services.Proto/Proxies/EventsGatewayProxy.cs
+++ b/Source/Tinkwell.Services.Proto/Proxies/EventsGatewayProxy.cs
@@ -6,14 +6,14 @@
 
 public sealed class EventsGatewayProxy(ServiceLocator locator) : IEventsGateway
 {
-    /// <inheritdocs />
+    /// <inheritdoc />
     public async Task PublishAsync(PublishEventsRequest request, CancellationToken cancellationToken)
     {
         var client = await GetClient();
         await client.PublishAsync(request, cancellationToken: cancellationToken);
     }
 
-    /// <inheritdocs />
+    /// <inheritdoc />
     public async ValueTask<IStreamingResponse<SubscribeEventsResponse>> SubscribeManyAsync(IEnumerable<SubscribeToMatchingManyEventsRequest.Types.Match> matches, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(matches, nameof(matches));
@@ -26,7 +26,7 @@ public sealed class EventsGatewayProxy(ServiceLocator locator) : IEventsGateway
             client.SubscribeToMatchingMany(request, cancellationToken: cancellationToken));
     }
 
-    /// <inheritdocs />
+    /// <inheritdoc />
     public ValueTask DisposeAsync()
     {
         if (_gateway is not null)

--- a/Source/Tinkwell.Services.Proto/Proxies/StoreProxy.cs
+++ b/Source/Tinkwell.Services.Proto/Proxies/StoreProxy.cs
@@ -7,21 +7,21 @@ namespace Tinkwell.Services.Proto.Proxies;
 /// </summary>
 public sealed class StoreProxy(ServiceLocator locator) : IStore
 {
-    /// <inheritdocs />
+    /// <inheritdoc />
     public async Task RegisterManyAsync(StoreRegisterManyRequest request, CancellationToken cancellationToken)
     {
         var client = await GetClient();
         await client.RegisterManyAsync(request, cancellationToken: cancellationToken);
     }
 
-    /// <inheritdocs />
+    /// <inheritdoc />
     public async Task<StoreValueList> ReadManyAsync(IEnumerable<string> names, CancellationToken cancellationToken)
     {
         var client = await GetClient();
         return await client.ReadManyAsync(new() { Names = { names } }, cancellationToken: cancellationToken);
     }
 
-    /// <inheritdocs />
+    /// <inheritdoc />
     public async Task WriteQuantityAsync(string name, double value, CancellationToken cancellationToken)
     {
         var request = new StoreUpdateRequest
@@ -34,7 +34,7 @@ public sealed class StoreProxy(ServiceLocator locator) : IStore
         await client.UpdateAsync(request, cancellationToken: cancellationToken);
     }
 
-    /// <inheritdocs />
+    /// <inheritdoc />
     public async Task WriteQuantityAsync(string name, string value, CancellationToken cancellationToken)
     {
         var request = new StoreSetMeasureValueRequest
@@ -48,7 +48,7 @@ public sealed class StoreProxy(ServiceLocator locator) : IStore
         await client.SetMeasureValueAsync(request, cancellationToken: cancellationToken);
     }
 
-    /// <inheritdocs />
+    /// <inheritdoc />
     public async Task WriteStringAsync(string name, string value, CancellationToken cancellationToken)
     {
         var request = new StoreUpdateRequest
@@ -61,7 +61,7 @@ public sealed class StoreProxy(ServiceLocator locator) : IStore
         await client.UpdateAsync(request, cancellationToken: cancellationToken);
     }
 
-    /// <inheritdocs />
+    /// <inheritdoc />
     public async ValueTask<IStreamingResponse<StoreValueChange>> SubscribeManyAsync(IEnumerable<string> names, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(names, nameof(names));
@@ -74,7 +74,7 @@ public sealed class StoreProxy(ServiceLocator locator) : IStore
             client.SubscribeMany(request, cancellationToken: cancellationToken));
     }
 
-    /// <inheritdocs />
+    /// <inheritdoc />
     public ValueTask DisposeAsync()
     {
         if (_store is not null)


### PR DESCRIPTION
A _normal_ usage of Tinkwell does not involve building from source:

* Install the latest version.
* Add a reference to Tinkwell.Bootstrapper to your project to write your own runners.
* Start enjoying.

This PR adds a workflow to publish Tinkwell.Bootstrapper as NuGet package each time a new release is published.